### PR TITLE
implement SliceableRepository

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 guavaVersion=24.1-jre
 mirageVersion=2.1.0
-sparWingsVersion=20200318-f6b38ab-SNAPSHOT
+sparWingsVersion=20200325-0f6f479-SNAPSHOT
 springDataCommonsVersion=2.1.5.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 guavaVersion=24.1-jre
 mirageVersion=2.1.0
-sparWingsVersion=0.39
+sparWingsVersion=20200318-f6b38ab-SNAPSHOT
 springDataCommonsVersion=2.1.5.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 guavaVersion=24.1-jre
 mirageVersion=2.1.0
-sparWingsVersion=20200325-0f6f479-SNAPSHOT
+sparWingsVersion=20200330-47dcbd6-SNAPSHOT
 springDataCommonsVersion=2.1.5.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 guavaVersion=24.1-jre
 mirageVersion=2.1.0
-sparWingsVersion=20200727-fa67641-SNAPSHOT
+sparWingsVersion=20201026-816d89e
 springDataCommonsVersion=2.1.5.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 guavaVersion=24.1-jre
 mirageVersion=2.1.0
-sparWingsVersion=20200727-21810a4-SNAPSHOT
+sparWingsVersion=20200727-fa67641-SNAPSHOT
 springDataCommonsVersion=2.1.5.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 guavaVersion=24.1-jre
 mirageVersion=2.1.0
-sparWingsVersion=20200330-47dcbd6-SNAPSHOT
+sparWingsVersion=20200331-bd4bda3-SNAPSHOT
 springDataCommonsVersion=2.1.5.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 guavaVersion=24.1-jre
 mirageVersion=2.1.0
-sparWingsVersion=20200331-bd4bda3-SNAPSHOT
+sparWingsVersion=20200727-21810a4-SNAPSHOT
 springDataCommonsVersion=2.1.5.RELEASE

--- a/src/main/java/jp/xet/springframework/data/mirage/repository/DefaultMirageRepository.java
+++ b/src/main/java/jp/xet/springframework/data/mirage/repository/DefaultMirageRepository.java
@@ -69,7 +69,11 @@ import jp.xet.sparwings.spring.data.repository.ChunkableRepository;
 import jp.xet.sparwings.spring.data.repository.LockableCrudRepository;
 import jp.xet.sparwings.spring.data.repository.PageableRepository;
 import jp.xet.sparwings.spring.data.repository.ScannableRepository;
+import jp.xet.sparwings.spring.data.repository.SliceableRepository;
 import jp.xet.sparwings.spring.data.repository.TruncatableRepository;
+import jp.xet.sparwings.spring.data.slice.Slice;
+import jp.xet.sparwings.spring.data.slice.SliceImpl;
+import jp.xet.sparwings.spring.data.slice.Sliceable;
 
 /**
  * Mirage SQLを利用した repository 実装クラス。
@@ -81,7 +85,8 @@ import jp.xet.sparwings.spring.data.repository.TruncatableRepository;
  */
 public class DefaultMirageRepository<E, ID extends Serializable> implements ScannableRepository<E, ID>,
 		BatchReadableRepository<E, ID>, BatchWritableRepository<E, ID>, LockableCrudRepository<E, ID>,
-		ChunkableRepository<E, ID>, PageableRepository<E, ID>, TruncatableRepository<E, ID> {
+		ChunkableRepository<E, ID>, PageableRepository<E, ID>, SliceableRepository<E, ID>,
+		TruncatableRepository<E, ID> {
 	
 	private static Logger log = LoggerFactory.getLogger(DefaultMirageRepository.class);
 	
@@ -317,6 +322,33 @@ public class DefaultMirageRepository<E, ID extends Serializable> implements Scan
 			List<E> result = getResultList(getBaseSelectSqlResource(), createParams(pageable));
 			Long foundRows = getFoundRows();
 			return new PageImpl<E>(result, pageable, foundRows != null ? foundRows : count());
+		} catch (SQLRuntimeException e) {
+			throw getExceptionTranslator().translate("findAll", null, e.getCause());
+		}
+	}
+	
+	@Override
+	public Slice<E> findAll(Sliceable sliceable) {
+		if (null == sliceable) {
+			return new SliceImpl<>(newArrayList(findAll()), null, false);
+		}
+		
+		try {
+			Map<String, Object> parameter = createParams(sliceable);
+			List<E> result = getResultList(getBaseSelectSqlResource(), parameter);
+			
+			boolean hasNext = false;
+			Integer size = (Integer) parameter.get("size");
+			if (size != null) {
+				if (size == result.size()) {
+					// パラメータの size は Sliceable#getMaxContentSize() + 1 にしているので、
+					// それと同じ件数の場合は、次ページ有り & result の要素を切り詰める
+					hasNext = true;
+					result = result.subList(0, sliceable.getMaxContentSize());
+				}
+			}
+			
+			return new SliceImpl<>(result, sliceable, hasNext);
 		} catch (SQLRuntimeException e) {
 			throw getExceptionTranslator().translate("findAll", null, e.getCause());
 		}
@@ -560,6 +592,17 @@ public class DefaultMirageRepository<E, ID extends Serializable> implements Scan
 	protected Map<String, Object> createParams(Pageable pageable) {
 		Map<String, Object> params = createParams();
 		addPageParam(params, pageable);
+		return params;
+	}
+	
+	/**
+	 * Slice のパラメータ作成.
+	 * @param sliceable Sliceable
+	 * @return パラメータ
+	 */
+	protected Map<String, Object> createParams(Sliceable sliceable) {
+		Map<String, Object> params = createParams();
+		addSliceParam(params, sliceable);
 		return params;
 	}
 	
@@ -916,6 +959,12 @@ public class DefaultMirageRepository<E, ID extends Serializable> implements Scan
 				params.put("orders", join(orders));
 			}
 		}
+	}
+	
+	private void addSliceParam(Map<String, Object> params, Sliceable sliceable) {
+		params.put("offset", sliceable == null ? null : sliceable.getOffset());
+		params.put("size", sliceable == null ? null : sliceable.getMaxContentSize() + 1); // +1 することで次ページの存在を判定
+		params.put("direction", sliceable == null ? null : sliceable.getDirection().name());
 	}
 	
 	private void addSortParam(Map<String, Object> params, Sort sort) {

--- a/src/main/java/jp/xet/springframework/data/mirage/repository/DefaultMirageRepository.java
+++ b/src/main/java/jp/xet/springframework/data/mirage/repository/DefaultMirageRepository.java
@@ -334,6 +334,7 @@ public class DefaultMirageRepository<E, ID extends Serializable> implements Scan
 		}
 		
 		try {
+			sliceable.validate();
 			Map<String, Object> parameter = createParams(sliceable);
 			List<E> result = getResultList(getBaseSelectSqlResource(), parameter);
 			

--- a/src/main/java/jp/xet/springframework/data/mirage/repository/query/MirageQuery.java
+++ b/src/main/java/jp/xet/springframework/data/mirage/repository/query/MirageQuery.java
@@ -408,6 +408,7 @@ public class MirageQuery implements RepositoryQuery {
 			Class<?> returnedDomainType, SliceableParameterAccessor accessor) {
 		Sliceable sliceable = accessor.getSliceable();
 		if (sliceable != null) {
+			sliceable.validate();
 			addSliceParam(parameterMap, sliceable);
 		}
 		

--- a/src/main/java/jp/xet/springframework/data/mirage/repository/query/MirageQuery.java
+++ b/src/main/java/jp/xet/springframework/data/mirage/repository/query/MirageQuery.java
@@ -34,7 +34,6 @@ import java.util.Optional;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.domain.Sort.Order;
@@ -55,6 +54,8 @@ import jp.xet.sparwings.spring.data.chunk.Chunkable;
 import jp.xet.sparwings.spring.data.chunk.Chunkable.PaginationRelation;
 import jp.xet.sparwings.spring.data.chunk.PaginationTokenEncoder;
 import jp.xet.sparwings.spring.data.chunk.SimplePaginationTokenEncoder;
+import jp.xet.sparwings.spring.data.slice.SliceImpl;
+import jp.xet.sparwings.spring.data.slice.Sliceable;
 
 import jp.xet.springframework.data.mirage.repository.ScopeClasspathSqlResource;
 import jp.xet.springframework.data.mirage.repository.SqlResourceCandidate;
@@ -103,6 +104,15 @@ public class MirageQuery implements RepositoryQuery {
 			Sort sort = pageable.getSort();
 			addSortParam(params, sort);
 		}
+	}
+	
+	private static void addSliceParam(Map<String, Object> params, Sliceable sliceable) {
+		if (sliceable == null) {
+			return;
+		}
+		params.put("offset", sliceable.getOffset());
+		params.put("size", sliceable.getMaxContentSize() + 1); // +1 することで次ページの存在を判定
+		params.put("direction", sliceable.getDirection().name());
 	}
 	
 	private static void addSortParam(Map<String, Object> params, Sort sort) {
@@ -195,7 +205,11 @@ public class MirageQuery implements RepositoryQuery {
 		} else if (mirageQueryMethod.isChunkQuery()) {
 			return processChunkQuery(sqlResource, parameterMap, returnedDomainType, accessor);
 		} else if (mirageQueryMethod.isSliceQuery()) {
-			return processSliceQuery(sqlResource, parameterMap, returnedDomainType, accessor);
+			SliceableSupportedParameters sliceableSupportedParameters =
+					new SliceableSupportedParameters(mirageQueryMethod.asMethod());
+			SliceableParameterAccessor sliceAccessor =
+					new ParameterSliceableParameterAccessor(sliceableSupportedParameters, parameters);
+			return processSliceQuery(sqlResource, parameterMap, returnedDomainType, sliceAccessor);
 		} else if (mirageQueryMethod.isPageQuery()) {
 			return processPageQuery(sqlResource, parameterMap, returnedDomainType, accessor);
 		} else {
@@ -243,7 +257,8 @@ public class MirageQuery implements RepositoryQuery {
 			p.getName().ifPresent(parameterName -> parameterMap.put(parameterName, parameters[p.getIndex()]));
 			if (p.getName().isPresent() == false) {
 				if (Pageable.class.isAssignableFrom(p.getType()) == false
-						&& Chunkable.class.isAssignableFrom(p.getType()) == false) {
+						&& Chunkable.class.isAssignableFrom(p.getType()) == false
+						&& Sliceable.class.isAssignableFrom(p.getType()) == false) {
 					log.warn("null name parameter [{}] is ignored", p);
 				}
 			}
@@ -390,22 +405,29 @@ public class MirageQuery implements RepositoryQuery {
 	}
 	
 	private Object processSliceQuery(SqlResource sqlResource, Map<String, Object> parameterMap,
-			Class<?> returnedDomainType, ChunkableParameterAccessor accessor) {
-		Pageable pageable = accessor.getPageable();
-		if (pageable != null) {
-			addPageParam(parameterMap, pageable);
+			Class<?> returnedDomainType, SliceableParameterAccessor accessor) {
+		Sliceable sliceable = accessor.getSliceable();
+		if (sliceable != null) {
+			addSliceParam(parameterMap, sliceable);
 		} else if (accessor.getSort() != null) {
 			Sort sort = accessor.getSort();
 			addSortParam(parameterMap, sort);
 		}
 		
 		List<?> resultList = sqlManager.getResultList(returnedDomainType, sqlResource, parameterMap);
+		boolean hasNext = false;
+		Integer size = (Integer) parameterMap.get("size");
+		if (size != null && size == resultList.size()) {
+			// パラメータの size は Sliceable#getMaxContentSize() + 1 にしているので、
+			// それと同じ件数の場合は、次ページ有り & result の要素を切り詰める
+			hasNext = true;
+			resultList = resultList.subList(0, sliceable.getMaxContentSize());
+		}
 		
 		if (List.class.isAssignableFrom(mirageQueryMethod.getReturnType())) {
 			return resultList;
 		}
-		
-		return new SliceImpl<>(resultList, pageable, true/*TODO*/);
+		return new SliceImpl<>(resultList, sliceable, hasNext);
 	}
 	
 	private String toString(Reader input) throws IOException {

--- a/src/main/java/jp/xet/springframework/data/mirage/repository/query/MirageQuery.java
+++ b/src/main/java/jp/xet/springframework/data/mirage/repository/query/MirageQuery.java
@@ -409,9 +409,6 @@ public class MirageQuery implements RepositoryQuery {
 		Sliceable sliceable = accessor.getSliceable();
 		if (sliceable != null) {
 			addSliceParam(parameterMap, sliceable);
-		} else if (accessor.getSort() != null) {
-			Sort sort = accessor.getSort();
-			addSortParam(parameterMap, sort);
 		}
 		
 		List<?> resultList = sqlManager.getResultList(returnedDomainType, sqlResource, parameterMap);

--- a/src/main/java/jp/xet/springframework/data/mirage/repository/query/MirageQueryMethod.java
+++ b/src/main/java/jp/xet/springframework/data/mirage/repository/query/MirageQueryMethod.java
@@ -32,6 +32,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 import jp.xet.sparwings.spring.data.chunk.Chunk;
+import jp.xet.sparwings.spring.data.slice.Slice;
 
 /**
  * TODO for daisuke
@@ -118,6 +119,15 @@ public class MirageQueryMethod extends QueryMethod {
 	 */
 	public boolean isChunkQuery() {
 		return !isPageQuery() && org.springframework.util.ClassUtils.isAssignable(Chunk.class, unwrappedReturnType);
+	}
+	
+	/**
+	 * Slice 形式の Query か？
+	 * @return Slice 形式の Query の場合、true
+	 */
+	@Override
+	public boolean isSliceQuery() {
+		return !isPageQuery() && org.springframework.util.ClassUtils.isAssignable(Slice.class, unwrappedReturnType);
 	}
 	
 	/**

--- a/src/main/java/jp/xet/springframework/data/mirage/repository/query/ParameterSliceableParameterAccessor.java
+++ b/src/main/java/jp/xet/springframework/data/mirage/repository/query/ParameterSliceableParameterAccessor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2011-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.springframework.data.mirage.repository.query;
+
+import org.springframework.data.repository.query.Parameters;
+import org.springframework.data.repository.query.ParametersParameterAccessor;
+
+import jp.xet.sparwings.spring.data.slice.Sliceable;
+
+/**
+ * Sliceable の ParameterAccessor.
+ */
+public class ParameterSliceableParameterAccessor extends ParametersParameterAccessor
+		implements SliceableParameterAccessor {
+	
+	private final Parameters<?, ?> parameters;
+	
+	private final Object[] values;
+	
+	
+	/**
+	 * インスタンスを生成する。
+	 * 
+	 * @param parameters Parameters
+	 * @param values 引数の値
+	 */
+	public ParameterSliceableParameterAccessor(Parameters<?, ?> parameters, Object[] values) {
+		super(parameters, values);
+		this.parameters = parameters;
+		this.values = values.clone();
+	}
+	
+	@Override
+	public Sliceable getSliceable() {
+		if (parameters instanceof SliceableSupportedParameters) {
+			SliceableSupportedParameters sliceableSupportedParameters = (SliceableSupportedParameters) parameters;
+			if (sliceableSupportedParameters.hasSliceableParameter() == false) {
+				return null;
+			}
+			return (Sliceable) values[sliceableSupportedParameters.getSliceableIndex()];
+		}
+		return null;
+	}
+}

--- a/src/main/java/jp/xet/springframework/data/mirage/repository/query/SliceableParameterAccessor.java
+++ b/src/main/java/jp/xet/springframework/data/mirage/repository/query/SliceableParameterAccessor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2011-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.springframework.data.mirage.repository.query;
+
+import org.springframework.data.repository.query.ParameterAccessor;
+
+import jp.xet.sparwings.spring.data.slice.Sliceable;
+
+/**
+ * Sliceable のパラメータアクセッサ.
+ */
+public interface SliceableParameterAccessor extends ParameterAccessor {
+	
+	/**
+	 * Returns the {@link Sliceable} of the parameters, if available. Returns {@code null} otherwise.
+	 * 
+	 * @return Sliceable
+	 */
+	Sliceable getSliceable();
+	
+}

--- a/src/main/java/jp/xet/springframework/data/mirage/repository/query/SliceableSupportedParameter.java
+++ b/src/main/java/jp/xet/springframework/data/mirage/repository/query/SliceableSupportedParameter.java
@@ -18,26 +18,17 @@ package jp.xet.springframework.data.mirage.repository.query;
 import org.springframework.core.MethodParameter;
 import org.springframework.data.repository.query.Parameter;
 
-import jp.xet.sparwings.spring.data.chunk.Chunkable;
+import jp.xet.sparwings.spring.data.slice.Sliceable;
 
 /**
- * TODO for daisuke
- * 
- * @since TODO for daisuke
- * @version $Id$
- * @author daisuke
+ * Sliceable をサポートするパラメータ.
  */
-public class ChunkableSupportedParameter extends Parameter {
+public class SliceableSupportedParameter extends Parameter {
 	
 	private MethodParameter parameter;
 	
 	
-	/**
-	 * インスタンスを生成する。
-	 * 
-	 * @param parameter
-	 */
-	public ChunkableSupportedParameter(MethodParameter parameter) {
+	public SliceableSupportedParameter(MethodParameter parameter) {
 		super(parameter);
 		this.parameter = parameter;
 	}
@@ -48,11 +39,11 @@ public class ChunkableSupportedParameter extends Parameter {
 	}
 	
 	/**
-	 * Returns whether the {@link Parameter} is a {@link Chunkable} parameter.
+	 * Returns whether the {@link Parameter} is a {@link Sliceable} parameter.
 	 * 
-	 * @return
+	 * @return Sliceable のパラメータを保持している場合、true
 	 */
-	boolean isChunkable() {
-		return Chunkable.class.isAssignableFrom(getType());
+	boolean isSliceable() {
+		return Sliceable.class.isAssignableFrom(getType());
 	}
 }

--- a/src/main/java/jp/xet/springframework/data/mirage/repository/query/SliceableSupportedParameters.java
+++ b/src/main/java/jp/xet/springframework/data/mirage/repository/query/SliceableSupportedParameters.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2011-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.springframework.data.mirage.repository.query;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.repository.query.DefaultParameters;
+import org.springframework.data.repository.query.Parameters;
+
+import jp.xet.sparwings.spring.data.slice.Sliceable;
+
+/**
+ * Sliceable の パラメータ.
+ */
+public class SliceableSupportedParameters
+		extends Parameters<SliceableSupportedParameters, SliceableSupportedParameter> {
+	
+	/** Sliceable パラメータの index. */
+	private int sliceableIndex;
+	
+	
+	/**
+	 * Creates a new {@link DefaultParameters} instance from the given {@link Method}.
+	 * 
+	 * @param method must not be {@literal null}.
+	 */
+	public SliceableSupportedParameters(Method method) {
+		super(method);
+		List<Class<?>> types = Arrays.asList(method.getParameterTypes());
+		sliceableIndex = types.indexOf(Sliceable.class);
+	}
+	
+	private SliceableSupportedParameters(List<SliceableSupportedParameter> originals) {
+		super(originals);
+		
+		for (int i = 0; i < originals.size(); i++) {
+			SliceableSupportedParameter original = originals.get(i);
+			if (original.isSliceable()) {
+				sliceableIndex = i;
+				return;
+			}
+		}
+		sliceableIndex = -1;
+	}
+	
+	/**
+	 * Returns the index of the {@link Sliceable} {@link Method} parameter if available. Will return {@literal -1} if there
+	 * is no {@link Sliceable} argument in the {@link Method}'s parameter list.
+	 * 
+	 * @return the sliceableIndex
+	 */
+	public int getSliceableIndex() {
+		return sliceableIndex;
+	}
+	
+	/**
+	 * Returns whether the method the {@link Parameters} was created for contains a {@link Sliceable} argument.
+	 * 
+	 * @return Sliceable のパラメータ指定が存在する場合、true
+	 */
+	public boolean hasSliceableParameter() {
+		return sliceableIndex != -1;
+	}
+	
+	@Override
+	protected SliceableSupportedParameters createFrom(List<SliceableSupportedParameter> parameters) {
+		return new SliceableSupportedParameters(parameters);
+	}
+	
+	@Override
+	protected SliceableSupportedParameter createParameter(MethodParameter parameter) {
+		return new SliceableSupportedParameter(parameter);
+	}
+}

--- a/src/main/java/jp/xet/springframework/data/mirage/repository/query/SupportedParameterUtils.java
+++ b/src/main/java/jp/xet/springframework/data/mirage/repository/query/SupportedParameterUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2011-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.springframework.data.mirage.repository.query;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import jp.xet.sparwings.spring.data.chunk.Chunkable;
+import jp.xet.sparwings.spring.data.slice.Sliceable;
+
+/**
+ * SupportedParameter 用の Utils.
+ */
+public class SupportedParameterUtils {
+	
+	/** 
+	 * 特別なパラメータと判定する class List.
+	 * 
+	 * <p>新しい概念を追加する場合、追加してください。</p>
+	 */
+	private static final List<Class<?>> TYPES =
+			Arrays.asList(Pageable.class, Sort.class, Chunkable.class, Sliceable.class);
+	
+	
+	/**
+	 * Returns whether the parameter is a special parameter.
+	 * @param methodParameter MethodParameter
+	 * @return 特別なパラメータの場合、true
+	 */
+	public static boolean isSpecialParameter(MethodParameter methodParameter) {
+		return TYPES.contains(methodParameter.getParameterType());
+	}
+}

--- a/src/test/java/jp/xet/springframework/data/mirage/repository/example/Task.java
+++ b/src/test/java/jp/xet/springframework/data/mirage/repository/example/Task.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2011-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.springframework.data.mirage.repository.example;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.springframework.data.annotation.Id;
+
+import com.miragesql.miragesql.annotation.Column;
+import com.miragesql.miragesql.annotation.Table;
+
+@Table(name = "tasks")
+@SuppressWarnings("serial")
+public class Task implements Serializable {
+	
+	@Id
+	@Column(name = "task_id")
+	private String taskId;
+	
+	@Column(name = "task_name")
+	private String taskName;
+	
+	@Column(name = "deadline")
+	private Long deadline;
+	
+	
+	public Task(String taskName, Long deadline) {
+		this.taskId = UUID.randomUUID().toString();
+		this.taskName = taskName;
+		this.deadline = deadline;
+	}
+	
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (!(o instanceof Task))
+			return false;
+		Task task = (Task) o;
+		return Objects.equals(getTaskId(), task.getTaskId()) &&
+				Objects.equals(getTaskName(), task.getTaskName()) &&
+				Objects.equals(getDeadline(), task.getDeadline());
+	}
+	
+	@Override
+	public int hashCode() {
+		return Objects.hash(getTaskId(), getTaskName(), getDeadline());
+	}
+	
+	public String getTaskId() {
+		return taskId;
+	}
+	
+	public void setTaskId(String taskId) {
+		this.taskId = taskId;
+	}
+	
+	public String getTaskName() {
+		return taskName;
+	}
+	
+	public void setTaskName(String taskName) {
+		this.taskName = taskName;
+	}
+	
+	public Long getDeadline() {
+		return deadline;
+	}
+	
+	public void setDeadline(Long deadline) {
+		this.deadline = deadline;
+	}
+}

--- a/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskChunkableRepository.java
+++ b/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskChunkableRepository.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2011-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.springframework.data.mirage.repository.example;
+
+import jp.xet.sparwings.spring.data.repository.ChunkableRepository;
+import jp.xet.sparwings.spring.data.repository.WritableRepository;
+import jp.xet.sparwings.spring.data.slice.Slice;
+import jp.xet.sparwings.spring.data.slice.Sliceable;
+
+/**
+ * ChunkableRepository を extends して、Slice の戻り値のメソッドを定義した Repository.
+ */
+public interface TaskChunkableRepository extends WritableRepository<Task, String>, ChunkableRepository<Task, String> {
+	
+	/**
+	 * Slice 取得.
+	 * @param sliceable Slice 条件
+	 * @return 検索結果
+	 */
+	Slice<Task> findSlice(Sliceable sliceable);
+}

--- a/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskChunkableRepositoryTest.java
+++ b/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskChunkableRepositoryTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2011-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.springframework.data.mirage.repository.example;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jp.xet.sparwings.spring.data.slice.Slice;
+import jp.xet.sparwings.spring.data.slice.SliceRequest;
+import jp.xet.sparwings.spring.data.slice.Sliceable;
+
+import jp.xet.springframework.data.mirage.repository.TestConfiguration;
+
+/**
+ * ChunkableRepository を extends して、Slice の戻り値のメソッドを定義した Repository のテスト.
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = TestConfiguration.class)
+@Transactional
+public class TaskChunkableRepositoryTest {
+	
+	@Autowired
+	TaskChunkableRepository repos;
+	
+	
+	@Test
+	public void testFindSlice_ASC() {
+		// setup
+		Task task1 = repos.create(new Task("name1", null));
+		Task task2 = repos.create(new Task("name2", 2L));
+		Task task3 = repos.create(new Task("name4", 1L));
+		Task task4 = repos.create(new Task("name3", 3L));
+		
+		Sliceable firstSliceable = new SliceRequest(0, Sort.Direction.ASC, 3);
+		
+		// exercise(最初のページ)
+		Slice<Task> firstActual = repos.findSlice(firstSliceable);
+		
+		// verify
+		assertThat(firstActual).hasSize(3);
+		assertThat(firstActual.getContent().get(0)).isEqualTo(task1);
+		assertThat(firstActual.getContent().get(1)).isEqualTo(task3);
+		assertThat(firstActual.getContent().get(2)).isEqualTo(task2);
+		assertThat(firstActual.hasNext()).isTrue();
+		
+		// 次のページ
+		Sliceable nextSliceable = firstActual.nextSlice();
+		Slice<Task> nextActual = repos.findSlice(nextSliceable);
+		assertThat(nextActual).hasSize(1);
+		assertThat(nextActual.getContent().get(0)).isEqualTo(task4);
+		assertThat(nextActual.hasNext()).isFalse();
+	}
+	
+	@Test
+	public void testFindSlice_DESC() {
+		// setup
+		Task task1 = repos.create(new Task("name1", null));
+		Task task2 = repos.create(new Task("name2", 2L));
+		Task task3 = repos.create(new Task("name4", 1L));
+		Task task4 = repos.create(new Task("name3", 3L));
+		
+		Sliceable firstSliceable = new SliceRequest(0, Sort.Direction.DESC, 3);
+		
+		// exercise(最初のページ)
+		Slice<Task> firstActual = repos.findSlice(firstSliceable);
+		
+		// verify
+		assertThat(firstActual).hasSize(3);
+		assertThat(firstActual.getContent().get(0)).isEqualTo(task4);
+		assertThat(firstActual.getContent().get(1)).isEqualTo(task2);
+		assertThat(firstActual.getContent().get(2)).isEqualTo(task3);
+		assertThat(firstActual.hasNext()).isTrue();
+		
+		// 次のページ
+		Sliceable nextSliceable = firstActual.nextSlice();
+		Slice<Task> nextActual = repos.findSlice(nextSliceable);
+		assertThat(nextActual).hasSize(1);
+		assertThat(nextActual.getContent().get(0)).isEqualTo(task1);
+		assertThat(nextActual.hasNext()).isFalse();
+	}
+}

--- a/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskRepository.java
+++ b/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskRepository.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2011-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.springframework.data.mirage.repository.example;
+
+import jp.xet.sparwings.spring.data.repository.SliceableRepository;
+import jp.xet.sparwings.spring.data.repository.WritableRepository;
+
+/**
+ * SliceableRepository のメソッド定義無し.
+ */
+public interface TaskRepository extends WritableRepository<Task, String>, SliceableRepository<Task, String> {
+}

--- a/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskRepositoryTest_NoSqlFile.java
+++ b/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskRepositoryTest_NoSqlFile.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2011-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.springframework.data.mirage.repository.example;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jp.xet.sparwings.spring.data.slice.Slice;
+import jp.xet.sparwings.spring.data.slice.SliceRequest;
+import jp.xet.sparwings.spring.data.slice.Sliceable;
+
+import jp.xet.springframework.data.mirage.repository.TestConfiguration;
+
+/**
+ * SliceableRepository の sql ファイル無しのテスト.
+ *
+ * repository の
+ * - {interface 名}.sql
+ * - {interface 名}_{メソッド名}.sql
+ * のファイルが存在しないので、baseSelect.sql を使用。
+ *
+ * <pre>
+ * SELECT *
+ * FROM {Entity の table の name}
+ * ORDER BY {Entity の @Id の column 名} {SliceRequest#getDirection}
+ * LIMIT {SliceRequest#getOffset},
+ * {SliceRequest#getMaxContentSize + 1}
+ * </pre>
+ * 
+ * の SQL が発行されること
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = TestConfiguration.class)
+@Transactional
+public class TaskRepositoryTest_NoSqlFile {
+	
+	@Autowired
+	TaskRepository repos;
+	
+	
+	@Test
+	public void testFindAll_ASC() {
+		// setup
+		Task task1 = repos.create(createTask("1-1", "name1", null));
+		Task task2 = repos.create(createTask("1-2", "name2", 2L));
+		Task task3 = repos.create(createTask("1-3", "name4", 1L));
+		Task task4 = repos.create(createTask("2-1", "name3", 3L));
+		
+		Sliceable firstSliceable = new SliceRequest(0, Sort.Direction.ASC, 3);
+		
+		// exercise(最初のページ)
+		// task_id 項目でソートを行う
+		Slice<Task> firstActual = repos.findAll(firstSliceable);
+		
+		// verify
+		assertThat(firstActual).hasSize(3);
+		assertThat(firstActual.getContent().get(0)).isEqualTo(task1);
+		assertThat(firstActual.getContent().get(1)).isEqualTo(task2);
+		assertThat(firstActual.getContent().get(2)).isEqualTo(task3);
+		assertThat(firstActual.hasNext()).isTrue();
+		
+		// 次のページ
+		Sliceable nextSliceable = firstActual.nextSlice();
+		Slice<Task> nextActual = repos.findAll(nextSliceable);
+		assertThat(nextActual).hasSize(1);
+		assertThat(nextActual.getContent().get(0)).isEqualTo(task4);
+		assertThat(nextActual.hasNext()).isFalse();
+	}
+	
+	@Test
+	public void testFindAll_DESC() {
+		// setup
+		Task task1 = repos.create(createTask("1-1", "name1", null));
+		Task task2 = repos.create(createTask("2-1", "name2", 2L));
+		Task task3 = repos.create(createTask("2-2", "name4", 1L));
+		Task task4 = repos.create(createTask("2-3", "name3", 3L));
+		
+		Sliceable firstSliceable = new SliceRequest(0, Sort.Direction.DESC, 3);
+		
+		// exercise(最初のページ)
+		// task_id 項目でソートを行う
+		Slice<Task> firstActual = repos.findAll(firstSliceable);
+		
+		// verify
+		assertThat(firstActual).hasSize(3);
+		assertThat(firstActual.getContent().get(0)).isEqualTo(task4);
+		assertThat(firstActual.getContent().get(1)).isEqualTo(task3);
+		assertThat(firstActual.getContent().get(2)).isEqualTo(task2);
+		assertThat(firstActual.hasNext()).isTrue();
+		
+		// 次のページ
+		Sliceable nextSliceable = firstActual.nextSlice();
+		Slice<Task> nextActual = repos.findAll(nextSliceable);
+		assertThat(nextActual).hasSize(1);
+		assertThat(nextActual.getContent().get(0)).isEqualTo(task1);
+		assertThat(nextActual.hasNext()).isFalse();
+	}
+	
+	private Task createTask(String taskId, String taskName, Long deadline) {
+		Task task = new Task(taskName, deadline);
+		task.setTaskId(taskId);
+		return task;
+	}
+}

--- a/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskSliceableFilterRepository.java
+++ b/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskSliceableFilterRepository.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2011-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.springframework.data.mirage.repository.example;
+
+import org.springframework.data.repository.query.Param;
+
+import jp.xet.sparwings.spring.data.repository.SliceableRepository;
+import jp.xet.sparwings.spring.data.repository.WritableRepository;
+import jp.xet.sparwings.spring.data.slice.Slice;
+import jp.xet.sparwings.spring.data.slice.Sliceable;
+
+public interface TaskSliceableFilterRepository
+		extends WritableRepository<Task, String>, SliceableRepository<Task, String> {
+	
+	/**
+	 * filter 条件込みで Slice 取得.
+	 * 
+	 * <p>
+	 * - 期限 From 指定時、期限 From <= tasks.deadline
+	 * - 期限 To 指定時、tasks.deadline <= 期限 To
+	 * を指定します。
+	 * </p>
+	 * @param deadlineFrom 期限From
+	 * @param deadlineTo 期限To
+	 * @param sliceable Slice 条件
+	 * @return 検索結果
+	 */
+	Slice<Task> withFilter(@Param("deadlineFrom") Long deadlineFrom,
+			@Param("deadlineTo") Long deadlineTo, Sliceable sliceable);
+}

--- a/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskSliceableFilterRepositoryTest.java
+++ b/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskSliceableFilterRepositoryTest.java
@@ -16,6 +16,7 @@
 package jp.xet.springframework.data.mirage.repository.example;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
@@ -26,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import jp.xet.sparwings.spring.data.exceptions.InvalidSliceableException;
 import jp.xet.sparwings.spring.data.slice.Slice;
 import jp.xet.sparwings.spring.data.slice.SliceRequest;
 import jp.xet.sparwings.spring.data.slice.Sliceable;
@@ -128,5 +130,18 @@ public class TaskSliceableFilterRepositoryTest {
 		assertThat(firstActual.getContent().get(1)).isEqualTo(task3);
 		assertThat(firstActual.getContent().get(2)).isEqualTo(task4);
 		assertThat(firstActual.hasNext()).isFalse();
+	}
+	
+	@Test
+	public void testWithFilter_InvalidSliceable() {
+		// setup
+		Sliceable sliceable = new SliceRequest(1, Sort.Direction.ASC, 1001);
+		
+		// exercise
+		Throwable actual = catchThrowable(() -> repos.withFilter(0L, 3L, sliceable));
+		
+		// verify
+		assertThat(actual).isInstanceOfSatisfying(InvalidSliceableException.class,
+				e -> assertThat(e.getMessage()).isEqualTo("Cannot get elements beyond 2000."));
 	}
 }

--- a/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskSliceableFilterRepositoryTest.java
+++ b/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskSliceableFilterRepositoryTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2011-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.springframework.data.mirage.repository.example;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jp.xet.sparwings.spring.data.slice.Slice;
+import jp.xet.sparwings.spring.data.slice.SliceRequest;
+import jp.xet.sparwings.spring.data.slice.Sliceable;
+
+import jp.xet.springframework.data.mirage.repository.TestConfiguration;
+
+/**
+ * repository の
+ * - {interface 名}.sql
+ * 
+ * の sql ファイルのテスト
+ */
+@Transactional
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = TestConfiguration.class)
+public class TaskSliceableFilterRepositoryTest {
+	
+	@Autowired
+	TaskSliceableFilterRepository repos;
+	
+	
+	@Test
+	public void testWithFilter_ASC() {
+		// setup
+		repos.create(new Task("name1", 1L));
+		repos.create(new Task("name2", 2L));
+		Task task3 = repos.create(new Task("name3", 3L));
+		Task task4 = repos.create(new Task("name4", 4L));
+		Task task5 = repos.create(new Task("name5", 5L));
+		Task task6 = repos.create(new Task("name6", 5L));
+		
+		Sliceable firstSliceable = new SliceRequest(0, Sort.Direction.ASC, 3);
+		
+		// exercise(最初のページ)
+		Slice<Task> firstActual = repos.withFilter(3L, null, firstSliceable);
+		
+		// verify
+		assertThat(firstActual).hasSize(3);
+		assertThat(firstActual.getContent().get(0)).isEqualTo(task3);
+		assertThat(firstActual.getContent().get(1)).isEqualTo(task4);
+		assertThat(firstActual.getContent().get(2)).isEqualTo(task5);
+		assertThat(firstActual.hasNext()).isTrue();
+		
+		// 次のページ
+		Sliceable nextSliceable = firstActual.nextSlice();
+		Slice<Task> nextActual = repos.withFilter(3L, null, nextSliceable);
+		assertThat(nextActual).hasSize(1);
+		assertThat(nextActual.getContent().get(0)).isEqualTo(task6); // task_name のソート順でこの順番で取れる
+		assertThat(nextActual.hasNext()).isFalse();
+	}
+	
+	@Test
+	public void testWithFilter_DESC() {
+		// setup
+		Task task1 = repos.create(new Task("name1", 1L));
+		Task task2 = repos.create(new Task("name2", 2L));
+		Task task3 = repos.create(new Task("name3", 4L));
+		Task task4 = repos.create(new Task("name4", 4L));
+		repos.create(new Task("name5", 5L));
+		repos.create(new Task("name6", 6L));
+		
+		Sliceable firstSliceable = new SliceRequest(0, Sort.Direction.DESC, 3);
+		
+		// exercise(最初のページ)
+		Slice<Task> firstActual = repos.withFilter(null, 4L, firstSliceable);
+		
+		// verify
+		assertThat(firstActual).hasSize(3);
+		assertThat(firstActual.getContent().get(0)).isEqualTo(task4);
+		assertThat(firstActual.getContent().get(1)).isEqualTo(task3); // task_name のソート順でこの順番で取れる
+		assertThat(firstActual.getContent().get(2)).isEqualTo(task2);
+		assertThat(firstActual.hasNext()).isTrue();
+		
+		// 次のページ
+		Sliceable nextSliceable = firstActual.nextSlice();
+		Slice<Task> nextActual = repos.withFilter(null, 4L, nextSliceable);
+		assertThat(nextActual).hasSize(1);
+		assertThat(nextActual.getContent().get(0)).isEqualTo(task1);
+		assertThat(nextActual.hasNext()).isFalse();
+	}
+	
+	@Test
+	public void testWithFilter() {
+		// setup
+		repos.create(new Task("name1", 1L));
+		Task task2 = repos.create(new Task("name2", 2L));
+		Task task3 = repos.create(new Task("name3", 4L));
+		Task task4 = repos.create(new Task("name4", 4L));
+		repos.create(new Task("name5", 5L));
+		repos.create(new Task("name6", 6L));
+		
+		Sliceable firstSliceable = new SliceRequest(0, Sort.Direction.ASC, 3);
+		
+		// exercise
+		Slice<Task> firstActual = repos.withFilter(2L, 4L, firstSliceable);
+		
+		// verify
+		assertThat(firstActual).hasSize(3);
+		assertThat(firstActual.getContent().get(0)).isEqualTo(task2);
+		assertThat(firstActual.getContent().get(1)).isEqualTo(task3);
+		assertThat(firstActual.getContent().get(2)).isEqualTo(task4);
+		assertThat(firstActual.hasNext()).isFalse();
+	}
+}

--- a/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskSliceableRepository.java
+++ b/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskSliceableRepository.java
@@ -21,5 +21,5 @@ import jp.xet.sparwings.spring.data.repository.WritableRepository;
 /**
  * SliceableRepository のメソッド定義無し.
  */
-public interface TaskRepository extends WritableRepository<Task, String>, SliceableRepository<Task, String> {
+public interface TaskSliceableRepository extends WritableRepository<Task, String>, SliceableRepository<Task, String> {
 }

--- a/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskSliceableRepositoryTest_NoSqlFile.java
+++ b/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskSliceableRepositoryTest_NoSqlFile.java
@@ -53,10 +53,10 @@ import jp.xet.springframework.data.mirage.repository.TestConfiguration;
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = TestConfiguration.class)
 @Transactional
-public class TaskRepositoryTest_NoSqlFile {
+public class TaskSliceableRepositoryTest_NoSqlFile {
 	
 	@Autowired
-	TaskRepository repos;
+	TaskSliceableRepository repos;
 	
 	
 	@Test

--- a/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskSliceableRepositoryTest_NoSqlFile.java
+++ b/src/test/java/jp/xet/springframework/data/mirage/repository/example/TaskSliceableRepositoryTest_NoSqlFile.java
@@ -16,6 +16,7 @@
 package jp.xet.springframework.data.mirage.repository.example;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
@@ -26,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import jp.xet.sparwings.spring.data.exceptions.InvalidSliceableException;
 import jp.xet.sparwings.spring.data.slice.Slice;
 import jp.xet.sparwings.spring.data.slice.SliceRequest;
 import jp.xet.sparwings.spring.data.slice.Sliceable;
@@ -115,6 +117,19 @@ public class TaskSliceableRepositoryTest_NoSqlFile {
 		assertThat(nextActual).hasSize(1);
 		assertThat(nextActual.getContent().get(0)).isEqualTo(task1);
 		assertThat(nextActual.hasNext()).isFalse();
+	}
+	
+	@Test
+	public void testFindAll_InvalidSliceable() {
+		// setup
+		Sliceable sliceable = new SliceRequest(1, Sort.Direction.ASC, 1001);
+		
+		// exercise
+		Throwable actual = catchThrowable(() -> repos.findAll(sliceable));
+		
+		// verify
+		assertThat(actual).isInstanceOfSatisfying(InvalidSliceableException.class,
+				e -> assertThat(e.getMessage()).isEqualTo("Cannot get elements beyond 2000."));
 	}
 	
 	private Task createTask(String taskId, String taskName, Long deadline) {

--- a/src/test/resources/create.sql
+++ b/src/test/resources/create.sql
@@ -7,3 +7,9 @@ CREATE TABLE users (
 	username VARCHAR(64) PRIMARY KEY,
 	password VARCHAR(64) NOT NULL
 );
+
+CREATE TABLE tasks (
+	task_id VARCHAR(128) PRIMARY KEY,
+	task_name VARCHAR(256) NOT NULL,
+	deadline BIGINT(20)
+);

--- a/src/test/resources/jp/xet/springframework/data/mirage/repository/example/TaskChunkableRepository_findSlice.sql
+++ b/src/test/resources/jp/xet/springframework/data/mirage/repository/example/TaskChunkableRepository_findSlice.sql
@@ -1,0 +1,15 @@
+SELECT
+    *
+FROM
+    tasks
+ORDER BY deadline /*$direction*/ASC
+/*BEGIN*/
+LIMIT
+	/*IF offset != null*/
+	/*offset*/0,
+	/*END*/
+
+	/*IF size != null*/
+	/*size*/10
+	/*END*/
+/*END*/

--- a/src/test/resources/jp/xet/springframework/data/mirage/repository/example/TaskSliceableFilterRepository.sql
+++ b/src/test/resources/jp/xet/springframework/data/mirage/repository/example/TaskSliceableFilterRepository.sql
@@ -1,0 +1,25 @@
+SELECT
+    *
+FROM
+    tasks
+/*BEGIN*/
+WHERE
+    /*IF deadlineFrom != null*/
+        AND /*deadlineFrom*/123 <= tasks.deadline
+    /*END*/
+    /*IF deadlineTo != null*/
+        AND tasks.deadline <= /*deadlineTo*/456 
+    /*END*/
+/*END*/
+-- ソート条件に複数項目指定する場合
+ORDER BY deadline /*$direction*/ASC, task_name /*$direction*/ASC
+/*BEGIN*/
+LIMIT
+	/*IF offset != null*/
+	/*offset*/0,
+	/*END*/
+
+	/*IF size != null*/
+	/*size*/10
+	/*END*/
+/*END*/

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -18,7 +18,7 @@
   <logger name="org.springframework" level="INFO" />
   <logger name="jp.xet.springframework.data.mirage" level="DEBUG" />
 
-  <logger name="com.miragesql.miragesql" level="WARN" />
+  <logger name="com.miragesql.miragesql" level="DEBUG" />
 
   <logger name="jdbc" level="WARN" />
   <logger name="jdbc.sqltiming" level="INFO" />


### PR DESCRIPTION
# 概要

#2 

https://github.com/classmethod/spar-wings/pull/6 の対応済みの spar-wings が必要

# 内容

SliceableRepository#findAll や
メソッドの戻り値に Slice を指定したメソッドに対して
Slice 形式の結果を返す

* DefaultMirageRepository
  * SliceableRepository#findAll の実装
* MirageQuery
  * メソッドの戻り値が Slice になっている場合の処理を実装
    * 元々似たような処理は存在しており、Spring 側の Pageable を受けるようになっていたが対応も中途半端だったので変更した