### PR TITLE
最初の Chunk 後に prev にトークンを渡した時、空の Chunk を返すようにする

### DIFF
--- a/src/main/java/jp/xet/springframework/data/mirage/repository/DefaultMirageRepository.java
+++ b/src/main/java/jp/xet/springframework/data/mirage/repository/DefaultMirageRepository.java
@@ -281,10 +281,7 @@ public class DefaultMirageRepository<E, ID extends Serializable> implements Scan
 			List<E> resultList = getResultList(getBaseSelectSqlResource(), param);
 			String pt = null;
 			if (resultList.isEmpty() == false) {
-				String firstKey = null;
-				if (chunkable.getPaginationToken() != null) {
-					firstKey = Objects.toString(getId(resultList.get(0)));
-				}
+				String firstKey = Objects.toString(getId(resultList.get(0)));
 				String lastKey = Objects.toString(getId(resultList.get(resultList.size() - 1)));
 				pt = encoder.encode(firstKey, lastKey);
 			}

--- a/src/main/java/jp/xet/springframework/data/mirage/repository/query/MirageQuery.java
+++ b/src/main/java/jp/xet/springframework/data/mirage/repository/query/MirageQuery.java
@@ -360,10 +360,7 @@ public class MirageQuery implements RepositoryQuery {
 		if (resultList.isEmpty()) {
 			return null;
 		}
-		String firstKey = null;
-		if (chunkable != null && chunkable.getPaginationToken() != null) {
-			firstKey = Objects.toString(getId(resultList.get(0)));
-		}
+		String firstKey = Objects.toString(getId(resultList.get(0)));
 		String lastKey = Objects.toString(getId(resultList.get(resultList.size() - 1)));
 		return encoder.encode(firstKey, lastKey);
 	}

--- a/src/test/java/jp/xet/springframework/data/mirage/repository/example/EntityRepositoryTest.java
+++ b/src/test/java/jp/xet/springframework/data/mirage/repository/example/EntityRepositoryTest.java
@@ -166,13 +166,19 @@ public class EntityRepositoryTest {
 		assertThat(repo.count(), is(3L));
 		Chunk<Entity> chunk1 = repo.findChunk(new ChunkRequest(1));
 		assertThat(chunk1.getContent().size(), is(1));
+		assertThat(chunk1.getPaginationToken(), is(notNullValue()));
 		
 		Entity foundBar = chunk1.iterator().next();
 		assertThat(foundBar.getId(), is(bar.getId()));
 		assertThat(foundBar.getStr(), is("bar"));
 		
+		Chunk<Entity> chunk0 = repo.findChunk(chunk1.prevChunkable());
+		assertThat(chunk0.getContent().size(), is(0));
+		assertThat(chunk0.getPaginationToken(), is(nullValue()));
+		
 		Chunk<Entity> chunk2 = repo.findChunk(chunk1.nextChunkable());
 		assertThat(chunk2.getContent().size(), is(1));
+		assertThat(chunk2.getPaginationToken(), is(notNullValue()));
 		
 		Entity foundBaz = chunk2.iterator().next();
 		assertThat(foundBaz.getId(), is(baz.getId()));


### PR DESCRIPTION
#3 の実装

https://github.com/dai0304/spring-data-mirage/pull/46/files と同じ修正