### PR TITLE
Use ClassPathResource

### DIFF
--- a/src/main/java/jp/xet/springframework/data/mirage/repository/ScopeClasspathSqlResource.java
+++ b/src/main/java/jp/xet/springframework/data/mirage/repository/ScopeClasspathSqlResource.java
@@ -15,11 +15,14 @@
  */
 package jp.xet.springframework.data.mirage.repository;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.util.Assert;
 
 import org.slf4j.Logger;
@@ -37,6 +40,8 @@ import com.miragesql.miragesql.ClasspathSqlResource;
 public class ScopeClasspathSqlResource extends ClasspathSqlResource {
 	
 	private static Logger log = LoggerFactory.getLogger(ScopeClasspathSqlResource.class);
+	
+	private ClassPathResource classPathResource;
 	
 	
 	private static boolean existsResource(String absolutePath) {
@@ -142,10 +147,16 @@ public class ScopeClasspathSqlResource extends ClasspathSqlResource {
 	 */
 	public ScopeClasspathSqlResource(SqlResourceCandidate[] candidates) {
 		super(toAbsolutePath(candidates));
+		classPathResource = new ClassPathResource(toAbsolutePath(candidates));
 	}
 	
 	@Override
 	public String toString() {
 		return "SimpleSqlResource " + super.toString().substring(20);
+	}
+	
+	@Override
+	public InputStream getInputStream() throws IOException {
+		return classPathResource.getInputStream();
 	}
 }


### PR DESCRIPTION
See spring-boot issue 15737

どうも ThreadPool 内のスレッドから取得した ContextClassLoader はシステム由来? のものであるらしく `main/resources` を参照してくれないため、スレッドから Repository のメソッドを invoke すると sql ファイルが見つからないようである。

そこで spring-data-mirage 側で ClassPathResource 経由で sql ファイルをロードするようにする。
(親クラスは `Thread.currentThread().getContextClassLoader().getInputStream()` しているのでオーバーライドする。)